### PR TITLE
Fix dotenv loading path

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,14 +430,16 @@ runtime. Typically, you'd add this to the beginning of your main script (e.g., m
 import os 
 from dotenv import load_dotenv 
 # Load environment variables from .env file 
-load_dotenv() 
-# Access API keys like this: 
-openai_api_key = os.getenv("OPENAI_API_KEY") 
-pinecone_api_key = os.getenv("PINECONE_API_KEY") 
-# ... and so on for other keys 
-3.  
-Crucial Security Note: 
-● The .env file must be added to your project's .gitignore file to prevent it from being 
+load_dotenv()
+# Access API keys like this:
+openai_api_key = os.getenv("OPENAI_API_KEY")
+pinecone_api_key = os.getenv("PINECONE_API_KEY")
+# ... and so on for other keys
+● The `ava_mods_chunker.py` script assumes the `.env` file is located in the
+  project root and loads it automatically using `load_dotenv()`.
+3.
+Crucial Security Note:
+● The .env file must be added to your project's .gitignore file to prevent it from being
 accidentally committed to the Git repository. 
 ● API keys grant access to paid services and sensitive data. Treat them like passwords. 
 ● Production tokens and keys should be managed with extreme care, ideally using secure 

--- a/gvjj-voice-agent_ready for embeding/ava_mods_chunker.py
+++ b/gvjj-voice-agent_ready for embeding/ava_mods_chunker.py
@@ -3,6 +3,7 @@ import json
 import argparse
 from sentence_transformers import SentenceTransformer
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 import pinecone
 
@@ -119,8 +120,9 @@ def main():
 
     # ——— NEW: optional Pinecone upload ———
     if args.pinecone_index:
-        # adjust path if needed:
-        load_dotenv(dotenv_path=r"c:\Users\drat8\OneDrive\Documents\gvjj-voice-agent_ready for embedding\.env.txt")
+        # Load environment variables from the project root
+        root_dir = Path(__file__).resolve().parent.parent
+        load_dotenv(root_dir / ".env")
         api_key = os.getenv("PINECONE_API_KEY")
         env     = os.getenv("PINECONE_ENV")
         if not api_key or not env:


### PR DESCRIPTION
## Summary
- load `.env` from the repository root instead of a hard-coded Windows path
- document the expectation in README

## Testing
- `python -m py_compile process_kb_chunks.py 'gvjj-voice-agent_ready for embeding/ava_mods_chunker.py'`