### PR TITLE
Update default modules path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ The knowledge base originates from `🤙AVA CORE KB MODS.docx` and is processed 
    python "gvjj-voice-agent_ready for embeding/ava_mods_chunker.py"
    ```
 6. **Test module retrieval**
-   ```bash
-   python "gvjj-voice-agent_ready for embeding/module_manager.py" \
-       -m "gvjj-voice-agent_ready for embeding/ava_modlist_chunks.jsonl" \
-       -i "Hello"
-   ```
+    ```bash
+    python "gvjj-voice-agent_ready for embeding/module_manager.py" -i "Hello"
+    ```
+    The `--modules` argument defaults to
+    `gvjj-voice-agent_ready for embeding/ava_modlist_chunks.jsonl`.
 
 ## Running Tests
 Run the unit tests to validate module data:

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -34,10 +34,11 @@ This reads `🤙AVA CORE KB MODS.docx` and writes `ava_modlist_chunks.jsonl` in 
 Use the generated file with `module_manager.py` to retrieve a module for a sample phrase:
 
 ```bash
-python "gvjj-voice-agent_ready for embeding/module_manager.py" \
-    -m "gvjj-voice-agent_ready for embeding/ava_modlist_chunks.jsonl" \
-    -i "Hello"
+python "gvjj-voice-agent_ready for embeding/module_manager.py" -i "Hello"
 ```
+
+The `--modules` argument defaults to
+`gvjj-voice-agent_ready for embeding/ava_modlist_chunks.jsonl`.
 
 You should see a selected module printed to the console.
 

--- a/gvjj-voice-agent_ready for embeding/module_manager.py
+++ b/gvjj-voice-agent_ready for embeding/module_manager.py
@@ -133,8 +133,12 @@ def print_module(m):
 
 def main():
     p = argparse.ArgumentParser()
-    p.add_argument('-m','--modules', default='modules.json',
-                   help='path to module JSON')
+    p.add_argument(
+        '-m',
+        '--modules',
+        default='gvjj-voice-agent_ready for embeding/ava_modlist_chunks.jsonl',
+        help='path to module JSONL'
+    )
     p.add_argument('-i','--input', help='user input text')
     p.add_argument('-o','--orchestrate', action='store_true',
                    help='full orchestration stack')


### PR DESCRIPTION
## Summary
- use ava_modlist_chunks.jsonl as the default modules file
- adjust README and RUNNING docs to note the new default

## Testing
- `python -m unittest discover -s tests`