### PR TITLE
Add .gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+__pycache__/
+*.pyc
+*.pyo
+.env
+venv/
+.env*/
+*.env
+# others
+*.pyd
+.Python
+build/
+Develop-Eggs/
+dist/
+.eggs/
+*.egg-info/
+*.egg
+pip-wheel-metadata/
+# Mac-specific files
+.DS_Store


### PR DESCRIPTION
## Summary
- create a `.gitignore` with common Python exclusions

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*