### PR TITLE
Fix module_manager import in tests

### DIFF
--- a/tests/test_module_manager.py
+++ b/tests/test_module_manager.py
@@ -2,7 +2,12 @@ import unittest
 import importlib.util
 from pathlib import Path
 
-MODULE_PATH = Path(__file__).resolve().parent.parent / "gvjj-voice-agent_ready for embeding" / "module_manager.py"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "ava"
+    / "module_manager.py"
+)
 spec = importlib.util.spec_from_file_location("module_manager", MODULE_PATH)
 module_manager = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module_manager)


### PR DESCRIPTION
## Summary
- fix path to `src/ava/module_manager.py` in tests

## Testing
- `python -m unittest discover -v`