### PR TITLE
Add task engine skeleton with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist/
 pip-wheel-metadata/
 # Mac-specific files
 .DS_Store
+
+module_performance.log
+task_engine.log

--- a/src/ava/task_engine.py
+++ b/src/ava/task_engine.py
@@ -1,0 +1,84 @@
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Callable, Dict, List
+
+
+class Task:
+    """Represents an executable task."""
+
+    def __init__(self, name: str, action: Callable[[], bool]):
+        self.name = name
+        self.action = action
+        self.success = None
+        self.output = ""
+
+    def run(self) -> bool:
+        try:
+            self.success = self.action()
+        except Exception as exc:  # pragma: no cover - for unexpected runtime issues
+            self.success = False
+            self.output = str(exc)
+        return self.success
+
+
+class TaskEngine:
+    """Simple engine to run a sequence of tasks with logging."""
+
+    def __init__(self, tasks: List[Task], log_path: Path | None = None):
+        self.tasks = tasks
+        self.log_path = log_path or Path("task_engine.log")
+        logging.basicConfig(
+            filename=self.log_path,
+            level=logging.INFO,
+            format="%(asctime)s %(message)s",
+        )
+
+    def run(self) -> Dict[str, bool]:
+        results = {}
+        for task in self.tasks:
+            ok = task.run()
+            results[task.name] = ok
+            logging.info("%s: %s", task.name, "SUCCESS" if ok else "FAIL")
+            if task.output:
+                logging.info(task.output)
+        return results
+
+
+# --- predefined actions -------------------------------------------------
+
+def validate_modules() -> bool:
+    """Run validate_modules.py and return True if no issues printed."""
+    script = Path(__file__).parent / "validate_modules.py"
+    result = subprocess.run([
+        "python",
+        str(script),
+    ], capture_output=True, text=True)
+    return "No issues found" in result.stdout
+
+
+def run_tests() -> bool:
+    """Execute the project's unit tests."""
+    result = subprocess.run([
+        "python",
+        "-m",
+        "unittest",
+        "discover",
+        "-v",
+    ])
+    return result.returncode == 0
+
+
+def main():  # pragma: no cover - CLI
+    tasks = [
+        Task("Validate modules", validate_modules),
+        Task("Run tests", run_tests),
+    ]
+    engine = TaskEngine(tasks)
+    results = engine.run()
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1,0 +1,31 @@
+import unittest
+import json
+from pathlib import Path
+import importlib.util
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "src" / "ava" / "task_engine.py"
+spec = importlib.util.spec_from_file_location("task_engine", MODULE_PATH)
+task_engine = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(task_engine)
+Task = task_engine.Task
+TaskEngine = task_engine.TaskEngine
+
+
+def dummy_true():
+    return True
+
+
+def dummy_false():
+    return False
+
+
+class TestTaskEngine(unittest.TestCase):
+    def test_run_all_tasks(self):
+        tasks = [Task("t1", dummy_true), Task("t2", dummy_false)]
+        engine = TaskEngine(tasks, log_path=Path("/tmp/task_engine_test.log"))
+        results = engine.run()
+        self.assertEqual(results, {"t1": True, "t2": False})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `task_engine` module that runs predefined tasks with logging
- add unit test for the task engine
- ignore runtime log files

## Testing
- `python -m unittest discover -v`