### PR TITLE
Add Twilio integration skeleton

### DIFF
--- a/integration_notes.md
+++ b/integration_notes.md
@@ -1,0 +1,14 @@
+# Integration Notes
+
+## Twilio Bridge
+- Added `src/ava/twilio_bridge.py` as a lightweight wrapper around the Twilio REST client.
+- Fallback to `src/ava/twilio_mock.py` when the library or credentials are missing or `USE_TWILIO_MOCK=true`.
+- `ModuleManager.log_interaction` now sends an SMS summary when environment variable `ENABLE_TWILIO_NOTIFICATIONS` is set to `"true"`.
+  - Destination number read from `NOTIFY_NUMBER` environment variable.
+
+## CRM Stub
+- Created `src/ava/crm_bridge.py` with `update_contact_status` placeholder.
+
+## Assumptions & TODOs
+- Real Twilio credentials (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`) and `TWILIO_TWIML_URL` must be provided in the environment for production use.
+- CRM integration requires implementation in `crm_bridge.py`.

--- a/integration_report.txt
+++ b/integration_report.txt
@@ -1,0 +1,14 @@
+Added Twilio integration wrapper and CRM stub.
+
+Files added:
+- `src/ava/twilio_bridge.py`
+- `src/ava/twilio_mock.py`
+- `src/ava/crm_bridge.py`
+- `integration_notes.md`
+
+Existing file updated:
+- `src/ava/module_manager.py` now optionally sends SMS notifications via `twilio_bridge`.
+
+Outstanding TODOs:
+- Implement real CRM logic in `crm_bridge.update_contact_status`.
+- Provide valid Twilio credentials and TwiML URL in environment variables for production.

--- a/src/ava/crm_bridge.py
+++ b/src/ava/crm_bridge.py
@@ -1,0 +1,4 @@
+def update_contact_status(contact_id: str, status: str) -> None:
+    """Stub for future CRM integration."""
+    # TODO: Implement with real CRM integration
+    pass

--- a/src/ava/twilio_bridge.py
+++ b/src/ava/twilio_bridge.py
@@ -1,0 +1,64 @@
+"""Lightweight wrapper around the Twilio client with optional mock fallback."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+import importlib.util
+from pathlib import Path
+
+try:
+    from twilio.rest import Client  # type: ignore
+except Exception:  # Twilio may not be installed
+    Client = None
+
+try:
+    from . import twilio_mock
+except Exception:  # pragma: no cover - allow import when run as script
+    _p = Path(__file__).resolve().parent / "twilio_mock.py"
+    spec = importlib.util.spec_from_file_location("twilio_mock", _p)
+    twilio_mock = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(twilio_mock)
+
+
+def _get_client() -> Optional["Client"]:
+    """Return a Twilio Client or ``None`` if credentials/library missing."""
+    if os.getenv("USE_TWILIO_MOCK", "false").lower() == "true":
+        return None
+    if Client is None:
+        logging.warning("Twilio library not available; falling back to mock.")
+        return None
+    sid = os.getenv("TWILIO_ACCOUNT_SID")
+    token = os.getenv("TWILIO_AUTH_TOKEN")
+    if not sid or not token:
+        logging.error("Twilio credentials missing; set TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN")
+        return None
+    return Client(sid, token)
+
+
+def send_sms(to_number: str, body: str, from_number: str | None = None) -> str | None:
+    """Send an SMS using Twilio or the mock implementation."""
+    client = _get_client()
+    if client is None:
+        return twilio_mock.send_sms(to_number, body, from_number)
+    from_number = from_number or os.getenv("TWILIO_FROM_NUMBER")
+    if not from_number:
+        logging.error("TWILIO_FROM_NUMBER not set; using mock sender")
+        return twilio_mock.send_sms(to_number, body, from_number)
+    msg = client.messages.create(to=to_number, from_=from_number, body=body)
+    return msg.sid
+
+
+def make_call(to_number: str, from_number: str | None = None, twiml_url: str | None = None) -> str | None:
+    """Initiate a voice call via Twilio or the mock implementation."""
+    client = _get_client()
+    if client is None:
+        return twilio_mock.make_call(to_number, from_number, twiml_url)
+    from_number = from_number or os.getenv("TWILIO_FROM_NUMBER")
+    twiml_url = twiml_url or os.getenv("TWILIO_TWIML_URL")
+    if not from_number or not twiml_url:
+        logging.error("TWILIO_FROM_NUMBER or TWILIO_TWIML_URL missing; using mock caller")
+        return twilio_mock.make_call(to_number, from_number, twiml_url)
+    call = client.calls.create(to=to_number, from_=from_number, url=twiml_url)
+    return call.sid

--- a/src/ava/twilio_mock.py
+++ b/src/ava/twilio_mock.py
@@ -1,0 +1,12 @@
+import logging
+
+def send_sms(to_number: str, body: str, from_number: str | None = None) -> str:
+    """Mock SMS sender that logs the message."""
+    logging.info("[MOCK SMS] to=%s from=%s body=%s", to_number, from_number, body)
+    return "mock-sms-id"
+
+
+def make_call(to_number: str, from_number: str | None = None, twiml_url: str | None = None) -> str:
+    """Mock call initiator that logs the call details."""
+    logging.info("[MOCK CALL] to=%s from=%s url=%s", to_number, from_number, twiml_url)
+    return "mock-call-id"


### PR DESCRIPTION
## Summary
- add Twilio bridge with optional mock fallback
- create simple Twilio mock
- stub out CRM bridge
- update ModuleManager to optionally send SMS notifications
- document integration steps and todos

## Testing
- `python -m unittest discover -v`