### PR TITLE
Add explanation for special module id

### DIFF
--- a/src/ava/module_manager.py
+++ b/src/ava/module_manager.py
@@ -48,6 +48,10 @@ class ModuleManager:
         "AVAMOD0029","AVAMOD0024","AVAMOD0026",
         "AVAMOD0032","AVAMOD0033","AVAMOD0034",
         "AVAMOD0010","AVAMOD0023","AVAMOD0030",
+        # NOTE: The last entry deliberately breaks the numeric pattern.
+        # It acts as a sentinel module for narrative-integrity overrides
+        # and is referenced in tests. Preserve this exact ID when
+        # refactoring the orchestration logic.
         "AVAMOD0035NarrativeIntegrityLockPhantomWallPatch"
     ]
 


### PR DESCRIPTION
## Summary
- explain the non-numeric module ID in ORCHESTRATION_SEQ so it isn't deleted

## Testing
- `python -m unittest`