### PR TITLE
Add Synthflow export and helper utilities

### DIFF
--- a/src/ava/booking_utils.py
+++ b/src/ava/booking_utils.py
@@ -1,0 +1,31 @@
+"""Helpers for booking and follow-up actions."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+from . import twilio_bridge
+
+
+# --- Booking handlers ---------------------------------------------------
+
+def get_availability() -> List[str]:
+    """Return mockable availability slots."""
+    return ["Tuesday 4:30", "Thursday 6:00"]
+
+
+def create_booking(slot: str, lead_name: str) -> Dict[str, str]:
+    """Create a booking record (placeholder implementation)."""
+    return {"slot": slot, "lead": lead_name, "status": "confirmed"}
+
+
+# --- Follow-up helpers --------------------------------------------------
+
+def send_followup_sms(to_number: str, message: str) -> str:
+    """Send a follow-up SMS via Twilio or the mock interface."""
+    sid = twilio_bridge.send_sms(to_number, message)
+    return sid or "mock-sid"
+
+
+def schedule_callback(to_number: str, day: str) -> Dict[str, str]:
+    """Schedule a callback (stub for Zapier or CRM)."""
+    return {"number": to_number, "day": day, "status": "scheduled"}

--- a/src/ava/dialogue_utils.py
+++ b/src/ava/dialogue_utils.py
@@ -1,0 +1,20 @@
+"""Tone mirroring and fallback helpers."""
+
+from typing import Literal
+
+Tone = Literal["hesitant", "confident", "overwhelmed", "neutral"]
+
+
+def mirror_tone(user_tone: Tone) -> str:
+    """Return Ava's tone based on user tone."""
+    mapping = {
+        "hesitant": "warm",
+        "confident": "snappy",
+        "overwhelmed": "soft",
+    }
+    return mapping.get(user_tone, "neutral")
+
+
+def fallback_response() -> str:
+    """Generic soft exit used when no module matches."""
+    return "Totally. I can text you some options if that's easier."

--- a/src/ava/synthflow_export.py
+++ b/src/ava/synthflow_export.py
@@ -1,0 +1,61 @@
+import json
+import argparse
+from pathlib import Path
+from typing import List, Dict, Any
+
+
+def load_modules(path: str) -> List[Dict[str, Any]]:
+    modules: List[Dict[str, Any]] = []
+    with open(path, 'r', encoding='utf-8') as f:
+        try:
+            modules = json.load(f)
+        except json.JSONDecodeError:
+            f.seek(0)
+            for line in f:
+                line = line.strip()
+                if line:
+                    modules.append(json.loads(line))
+    return modules
+
+
+def convert_to_synthflow(modules: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    sf_modules = []
+    for m in modules:
+        raw_tags = m.get('tags', [])
+        if isinstance(raw_tags, list):
+            tags = {k: v for k, v in (t.split('=', 1) for t in raw_tags if '=' in t)}
+        else:
+            tags = dict(item.split('=') for item in raw_tags.split(', ') if '=' in item)
+        sf_modules.append({
+            'id': m.get('module_id'),
+            'name': m.get('title'),
+            'intent': m.get('intent'),
+            'phase': m.get('phase'),
+            'tags': tags,
+            'utterances': m.get('trigger_phrases', []),
+            'response': m.get('response_snippet') or m.get('response') or '',
+            'fallback': m.get('fallback', '')
+        })
+    return sf_modules
+
+
+def export_to_file(data: List[Dict[str, Any]], path: str) -> None:
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    p = argparse.ArgumentParser(description='Export modules for Synthflow.')
+    p.add_argument('-i', '--input', default=str(Path('gvjj-voice-agent_ready for embeding') / 'ava_modlist_chunks.jsonl'),
+                   help='Path to ava_modlist_chunks.jsonl')
+    p.add_argument('-o', '--output', default='synthflow_modules.json', help='Output file path')
+    args = p.parse_args()
+
+    modules = load_modules(args.input)
+    sf_modules = convert_to_synthflow(modules)
+    export_to_file(sf_modules, args.output)
+    print(f'Exported {len(sf_modules)} modules to {args.output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_booking_utils.py
+++ b/tests/test_booking_utils.py
@@ -1,0 +1,26 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from ava import booking_utils
+
+
+class TestBookingUtils(unittest.TestCase):
+    def test_get_availability(self):
+        slots = booking_utils.get_availability()
+        self.assertEqual(len(slots), 2)
+
+    def test_create_booking(self):
+        result = booking_utils.create_booking("Tuesday 4:30", "Sam")
+        self.assertEqual(result["status"], "confirmed")
+
+    def test_send_followup_sms(self):
+        sid = booking_utils.send_followup_sms("+10000000000", "Hi")
+        self.assertTrue(sid)
+
+    def test_schedule_callback(self):
+        cb = booking_utils.schedule_callback("+10000000000", "Friday")
+        self.assertEqual(cb["status"], "scheduled")
+

--- a/tests/test_dialogue_utils.py
+++ b/tests/test_dialogue_utils.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from ava import dialogue_utils
+
+
+class TestDialogueUtils(unittest.TestCase):
+    def test_mirror_tone(self):
+        self.assertEqual(dialogue_utils.mirror_tone("hesitant"), "warm")
+        self.assertEqual(dialogue_utils.mirror_tone("confident"), "snappy")
+        self.assertEqual(dialogue_utils.mirror_tone("overwhelmed"), "soft")
+        self.assertEqual(dialogue_utils.mirror_tone("neutral"), "neutral")
+
+    def test_fallback_response(self):
+        text = dialogue_utils.fallback_response()
+        self.assertIn("text", text.lower() if isinstance(text, str) else "")
+

--- a/tests/test_synthflow_export.py
+++ b/tests/test_synthflow_export.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from ava import synthflow_export
+
+
+class TestSynthflowExport(unittest.TestCase):
+    def test_conversion(self):
+        mod_path = Path(__file__).resolve().parents[1] / "gvjj-voice-agent_ready for embeding" / "ava_modlist_chunks.jsonl"
+        modules = synthflow_export.load_modules(str(mod_path))
+        sf = synthflow_export.convert_to_synthflow(modules)
+        self.assertIsInstance(sf, list)
+        self.assertGreater(len(sf), 0)
+        first = sf[0]
+        self.assertIn('id', first)
+        self.assertIn('utterances', first)
+        self.assertIsInstance(first['utterances'], list)
+


### PR DESCRIPTION
## Summary
- add `synthflow_export` for converting AVA modules to Synthflow style JSON
- include `booking_utils` for booking and follow-up stubs
- provide tone helpers in `dialogue_utils`
- test Synthflow export, booking utils, and dialogue utils

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6841ecae77a883278fdb03820bf3c587